### PR TITLE
Add notion of app path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: Simulate routing within a 'shiny' application by observering
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Imports: 
     fs,
     htmltools,

--- a/R/link.R
+++ b/R/link.R
@@ -12,5 +12,5 @@
 pathLink <- function(href, ...) {
   stopifnot(is.character(href))
 
-  htmltools::a(..., href = href, `data-blaze` = NA)
+  htmltools::a(..., href = path_app(href), `data-blaze` = NA)
 }

--- a/R/paths.R
+++ b/R/paths.R
@@ -100,10 +100,10 @@ paths <- function(..., app_path = NULL) {
   old <- setwd(tmp)
   on.exit(setwd(old))
 
-  if (!is.null(app_path)) {
+  .globals$app_path <- if (!is.null(app_path)) {
     app_path <- gsub("^/|/$", "", app_path)
     dir_create(app_path, recurse = TRUE)
-    .globals$app_path <- app_path
+    app_path
   }
 
   lapply(routes, function(route) {

--- a/R/paths.R
+++ b/R/paths.R
@@ -178,3 +178,16 @@ as_paths.list <- function(x, ...) {
 as_paths.yml <- function(x, ...) {
   as_paths.list(unclass(x))
 }
+
+
+path_app <- function(path) {
+  if (!grepl("^/", path)) {
+    path <- paste0("/", path)
+  }
+
+  if (!is.null(.globals$app_path)) {
+    path <- paste0("/", .globals$app_path, path)
+  }
+
+  path
+}

--- a/R/paths.R
+++ b/R/paths.R
@@ -124,6 +124,8 @@ paths <- function(..., app_path = NULL) {
       d <- paste0("/", d)
     }
 
+    app_redirect <- if (is.null(app_path)) "" else paste0("/", app_path)
+
     cat(file = index, sprintf("
       <!DOCTYPE html>
       <html>
@@ -131,10 +133,10 @@ paths <- function(..., app_path = NULL) {
       // blaze: redirect /<pathname> to Shiny app using URL search query
       let {origin, pathname, search, hash} = window.location
       search = (search ? search + '&' : '?') + `redirect=${pathname}`
-      window.location.replace(origin + search + hash)
+      window.location.replace(origin + '%s' + search + hash)
       </script></head>
       <body>Redirecting</body>
-      </html>", d
+      </html>", app_redirect
     ))
   })
 

--- a/R/url.R
+++ b/R/url.R
@@ -109,18 +109,25 @@ peek_params <- function() {
 #' Push a new URL path or get the current path.
 #'
 #' @param path A character string specifying a new URL path
+#' @param mode Either `"push"` or `"replace"`. If `"push"`, the default, the
+#'   path is pushed onto the history stack and pressing the back button in the
+#'   browser will redirect to the current path (before pushing the path). If
+#'   `"replace"`, then the pushed path will replace the current path without
+#'   changing the next page in the browser's back button stack.
 #'
 #' @param session A reactive context, defaults to
 #'   `shiny::getDefaultReactiveDomain()`.
 #'
 #' @export
-pushPath <- function(path, session = getDefaultReactiveDomain()) {
+pushPath <- function(path, mode = c("push", "replace"), session = getDefaultReactiveDomain()) {
   path <- path_app(path)
+  mode <- match.arg(mode)
 
   path <- utils::URLencode(path)
 
   session$sendCustomMessage("blaze:pushstate", list(
-    path = path
+    path = path,
+    mode = mode
   ))
 }
 

--- a/R/url.R
+++ b/R/url.R
@@ -133,5 +133,7 @@ getPath <- function(session = getDefaultReactiveDomain()) {
   if (is.null(.globals$app_path)) {
     return(url)
   }
-  sub(paste0("/", .globals$app_path), "", url, fixed = TRUE)
+  url <- sub(paste0("/", .globals$app_path), "", url, fixed = TRUE)
+  if (!length(url) || !grepl("^/", url)) url <- paste0("/", url)
+  url
 }

--- a/R/url.R
+++ b/R/url.R
@@ -111,13 +111,7 @@ peek_params <- function() {
 #'
 #' @export
 pushPath <- function(path, session = getDefaultReactiveDomain()) {
-  if (!grepl("^/", path)) {
-    path <- paste0("/", path)
-  }
-
-  if (!is.null(.globals$app_path)) {
-    path <- paste0("/", .globals$app_path, path)
-  }
+  path <- path_app(path)
 
   path <- utils::URLencode(path)
 

--- a/R/url.R
+++ b/R/url.R
@@ -58,6 +58,10 @@ as_route <- function(x) {
     x <- gsub("/:([^/]*)", "/(?<\\1>[^/]+)", x)
   }
 
+  if (!is.null(.globals$app_path)) {
+    x <- paste0("/", .globals$app_path, "/", x)
+  }
+
   if (!grepl("^[\\^]", x)) {
     x <- paste0("^", x)
   }
@@ -107,6 +111,10 @@ peek_params <- function() {
 #'
 #' @export
 pushPath <- function(path, session = getDefaultReactiveDomain()) {
+  if (!is.null(.globals$app_path)) {
+    path <- paste0("/", .globals$app_path, path)
+  }
+
   if (!grepl("^/", path)) {
     path <- paste0("/", path)
   }
@@ -121,5 +129,9 @@ pushPath <- function(path, session = getDefaultReactiveDomain()) {
 #' @rdname pushPath
 #' @export
 getPath <- function(session = getDefaultReactiveDomain()) {
-  session$clientData$url_state
+  url <- session$clientData$url_state
+  if (is.null(.globals$app_path)) {
+    return(url)
+  }
+  sub(paste0("/", .globals$app_path), "", url, fixed = TRUE)
 }

--- a/R/url.R
+++ b/R/url.R
@@ -111,12 +111,12 @@ peek_params <- function() {
 #'
 #' @export
 pushPath <- function(path, session = getDefaultReactiveDomain()) {
-  if (!is.null(.globals$app_path)) {
-    path <- paste0("/", .globals$app_path, path)
-  }
-
   if (!grepl("^/", path)) {
     path <- paste0("/", path)
+  }
+
+  if (!is.null(.globals$app_path)) {
+    path <- paste0("/", .globals$app_path, path)
   }
 
   path <- utils::URLencode(path)

--- a/R/url.R
+++ b/R/url.R
@@ -58,8 +58,12 @@ as_route <- function(x) {
     x <- gsub("/:([^/]*)", "/(?<\\1>[^/]+)", x)
   }
 
+  if (!grepl("^/", x)) {
+    x <- paste0("/", x)
+  }
+
   if (!is.null(.globals$app_path)) {
-    x <- paste0("/", .globals$app_path, "/", x)
+    x <- paste0("/", .globals$app_path, x)
   }
 
   if (!grepl("^[\\^]", x)) {

--- a/inst/www/js/blaze.js
+++ b/inst/www/js/blaze.js
@@ -38,10 +38,16 @@
   })();
 
   window.addEventListener("DOMContentLoaded", function() {
-    var _path = function(path) {
+    var _path = function(path, mode) {
       const uri = pathURI(path);
       if (uri) {
-        history.pushState(uri, null, uri);
+        if ((mode || "push") === "push") {
+          history.pushState({uri, pathname: path}, null, uri);
+        } else if (mode === "replace") {
+          history.replaceState({uri, pathname: path}, null, uri);
+        } else {
+          throw `Unknown blaze::pushPath() mode: ${mode}`;
+        }
         sendState(path);
       }
     };
@@ -68,12 +74,13 @@
 
     Shiny.addCustomMessageHandler("blaze:pushstate", function(msg) {
       if (msg.path) {
-        _path(msg.path);
+        _path(msg.path, msg.mode || "push");
       }
     });
   });
 
   window.addEventListener("popstate", function(event) {
-    sendState(event.state.replace(/[?#].+$/, '') || "/");
+    let {pathname} = event.state || window.location;
+    sendState(pathname || "/");
   });
 })(window.jQuery, window.Shiny);

--- a/inst/www/js/blaze.js
+++ b/inst/www/js/blaze.js
@@ -39,9 +39,9 @@
 
   window.addEventListener("DOMContentLoaded", function() {
     var _path = function(path) {
-      path = pathURI(path);
-      if (path) {
-        history.pushState(path, null, path);
+      const uri = pathURI(path);
+      if (uri) {
+        history.pushState(uri, null, uri);
         sendState(path);
       }
     };

--- a/man/paths.Rd
+++ b/man/paths.Rd
@@ -4,11 +4,14 @@
 \alias{paths}
 \title{Declare Paths for Use with Shiny}
 \usage{
-paths(...)
+paths(..., app_path = NULL)
 }
 \arguments{
 \item{...}{Path names as character strings that will be valid entry points
 into your Shiny app.}
+
+\item{app_path}{The name of the sub-directory where your Shiny app is hosted,
+e.g. `host.com/<app_path>/`.}
 }
 \value{
 Invisibly writes temporary HTML files to be hosted by Shiny to

--- a/man/pushPath.Rd
+++ b/man/pushPath.Rd
@@ -5,12 +5,22 @@
 \alias{getPath}
 \title{Path utilities}
 \usage{
-pushPath(path, session = getDefaultReactiveDomain())
+pushPath(
+  path,
+  mode = c("push", "replace"),
+  session = getDefaultReactiveDomain()
+)
 
 getPath(session = getDefaultReactiveDomain())
 }
 \arguments{
 \item{path}{A character string specifying a new URL path}
+
+\item{mode}{Either `"push"` or `"replace"`. If `"push"`, the default, the
+path is pushed onto the history stack and pressing the back button in the
+browser will redirect to the current path (before pushing the path). If
+`"replace"`, then the pushed path will replace the current path without
+changing the next page in the browser's back button stack.}
 
 \item{session}{A reactive context, defaults to
 `shiny::getDefaultReactiveDomain()`.}


### PR DESCRIPTION
Shiny apps are often hosted as sub-directories, e.g. at `<user>.shinyapps.io/<app_name>`. This PR adds an `app_path` argument to `paths()` so that blaze knows where the app is hosted, where to redirect when creating page endpoints, and how to update the URL without unintentionally removing the app's path from the URL.